### PR TITLE
refactor: 댓글삭제

### DIFF
--- a/server/src/main/java/com/galaxy/novelit/comment/domain/CommentInfo.java
+++ b/server/src/main/java/com/galaxy/novelit/comment/domain/CommentInfo.java
@@ -17,6 +17,7 @@ public class CommentInfo extends BaseTimeEntity {
     private String commentNickname;
     private String commentUserUUID;
 
+    // 테스트코드용
     public CommentInfo(String commentUUID, String commentContent, String commentNickname, String commentUserUUID) {
         this.commentUUID = commentUUID;
         this.commentContent = commentContent;

--- a/server/src/main/java/com/galaxy/novelit/comment/entity/Comment.java
+++ b/server/src/main/java/com/galaxy/novelit/comment/entity/Comment.java
@@ -2,6 +2,7 @@ package com.galaxy.novelit.comment.entity;
 
 import com.galaxy.novelit.comment.domain.CommentInfo;
 import com.galaxy.novelit.comment.request.CommentAddRequest;
+import com.galaxy.novelit.comment.request.CommentDeleteRequest;
 import com.galaxy.novelit.comment.request.CommentUpdateRequest;
 import com.galaxy.novelit.common.exception.custom.CustomException;
 import com.galaxy.novelit.common.exception.custom.ErrorCode;
@@ -26,6 +27,7 @@ public class Comment {
     private String directoryUUID;
     private List<CommentInfo> commentInfoList;
 
+    // 테스트코드용
     public Comment(String _id, String spaceUUID, String directoryUUID, List<CommentInfo> commentInfoList) {
         this._id = _id;
         this.spaceUUID = spaceUUID;
@@ -60,23 +62,26 @@ public class Comment {
             .build();
     }
 
-    public void updateCommentInfoList(List<CommentInfo> list){
+    public void updateComment(List<CommentInfo> list){
         this.commentInfoList = list;
     }
 
-    public void updateCommentInfoList(CommentUpdateRequest commentUpdateRequest, String userUUID) {
+    public void updateComment(CommentUpdateRequest commentUpdateRequest, String userUUID) {
         validateCommentInfoList(this.commentInfoList);
 
-        for (CommentInfo info : commentInfoList) {
-            String curInfoUUID = info.getCommentUUID();
-            String updateCommentUUID = commentUpdateRequest.commentUUID();
-
-            if (curInfoUUID.equals(updateCommentUUID)) {
-                validateSameCommentWriter(info.getCommentUserUUID(), userUUID);
-                info.updateCommentContent(commentUpdateRequest.commentContent());
-                break;
+        for (CommentInfo commentInfo : commentInfoList) {
+            if (validateSameCommentWriter(commentInfo, commentUpdateRequest, userUUID)) {
+                commentInfo.updateCommentContent(commentUpdateRequest.commentContent());
+                return;
             }
         }
+
+        throw new CustomException(ErrorCode.BAD_REQUEST, "글쓴이가 아니거나 수정하려는 댓글이 없습니다.");
+    }
+    private boolean validateSameCommentWriter(CommentInfo commentInfo, CommentUpdateRequest commentUpdateRequest,
+                                              String loginUUID) {
+        return commentInfo.getCommentUUID().equals(commentUpdateRequest.commentUUID())
+                && commentInfo.getCommentUserUUID().equals(loginUUID);
     }
 
     private void validateCommentInfoList(List<CommentInfo> commentInfoList) {
@@ -85,11 +90,24 @@ public class Comment {
         }
     }
 
-    private void validateSameCommentWriter(String commentUserUUID, String loginUUID) {
-        if (!commentUserUUID.equals(loginUUID)) { // 일치
-            throw new CustomException(ErrorCode.NOT_COMMENT_WRITER);
+    public void deleteComment(CommentDeleteRequest commentDeleteRequest, String userUUID) {
+        validateCommentInfoList(this.commentInfoList);
+
+        for (CommentInfo commentInfo :commentInfoList) {
+            // 소설가인 경우 : 로그인한 사람이랑 같음. 비밀번호없음
+            if (validateSameCommentWriter(commentInfo, commentDeleteRequest, userUUID)) {
+                commentInfoList.remove(commentInfo);
+                updateComment(this.commentInfoList);
+                return;
+            }
         }
+        throw new CustomException(ErrorCode.BAD_REQUEST, "글쓴이가 아니거나 삭제하려는 댓글이 없습니다.");
     }
 
-
+    private boolean validateSameCommentWriter(CommentInfo commentInfo,
+                                              CommentDeleteRequest commentDeleteRequest,
+                                              String userUUID) {
+        return commentInfo.getCommentUUID().equals(commentDeleteRequest.commentUUID())
+                && commentInfo.getCommentUserUUID().equals(userUUID);
+    }
 }

--- a/server/src/main/java/com/galaxy/novelit/comment/service/CommentService.java
+++ b/server/src/main/java/com/galaxy/novelit/comment/service/CommentService.java
@@ -49,7 +49,7 @@ public class CommentService {
         CommentInfo commentInfo = CommentInfo.createCommentInfo(commentAddRequest, userUUID);
         commentInfoList.add(commentInfo);
 
-        comment.updateCommentInfoList(commentInfoList);
+        comment.updateComment(commentInfoList);
 
         commentRepository.save(comment);
     }
@@ -72,9 +72,10 @@ public class CommentService {
         Comment comment = commentRepository.findCommentBySpaceUUID(commentUpdateRequest.spaceUUID())
                 .orElseThrow(() -> new CustomException(ErrorCode.NO_SUCH_COMMENT));
 
-        comment.updateCommentInfoList(commentUpdateRequest, userUUID);
+        comment.updateComment(commentUpdateRequest, userUUID);
     }
 
+    // 테스트용
     @Transactional(readOnly = true)
     public CommentInfo getCommentInfo(String spaceUUID, String commentUUID) {
         Comment comment = commentRepository.findCommentBySpaceUUID(spaceUUID)
@@ -93,25 +94,9 @@ public class CommentService {
 
     @Transactional
     public void deleteComment(CommentDeleteRequest commentDeleteRequest, String userUUID) {
-        // 코멘트 서치
-        Comment comment = commentRepository.findCommentBySpaceUUID(
-                commentDeleteRequest.spaceUUID())
+        Comment comment = commentRepository.findCommentBySpaceUUID(commentDeleteRequest.spaceUUID())
                 .orElseThrow(() -> new CustomException(ErrorCode.NO_SUCH_COMMENT));
 
-        List<CommentInfo> commentInfoList = comment.getCommentInfoList();
-
-        // 세부 코멘트 서치
-        for (CommentInfo info :commentInfoList) {
-            // 소설가인 경우 : 로그인한 사람이랑 같음. 비밀번호없음
-            if (info.getCommentUUID().equals(commentDeleteRequest.commentUUID())
-                && info.getCommentUserUUID().equals(userUUID)) {
-                commentInfoList.remove(info);
-                comment.updateCommentInfoList(commentInfoList);
-                commentRepository.save(comment);
-                return;
-            }
-        }
-
-        throw new CustomException(ErrorCode.NO_SUCH_COMMENT_UUID, "method : deleteComment. 해당하는 코멘트 UUID가 없습니다!");
+        comment.deleteComment(commentDeleteRequest, userUUID);
     }
 }

--- a/server/src/main/java/com/galaxy/novelit/common/exception/custom/ErrorCode.java
+++ b/server/src/main/java/com/galaxy/novelit/common/exception/custom/ErrorCode.java
@@ -7,12 +7,22 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-    ACCESS_REFUSED(HttpStatus.UNAUTHORIZED, "권한이 없습니다!"),
-    DELETED_ELEMENT(HttpStatus.NOT_FOUND, "삭제된 자료입니다!"),
+    // 400 BAD_REQUEST
     EDIT_REFUSED(HttpStatus.BAD_REQUEST, "현재 편집이 불가능합니다!"),
     ILLEGAL_UUID(HttpStatus.BAD_REQUEST, "UUID 오류입니다!"),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다!"),
     NON_UNIQUE(HttpStatus.BAD_REQUEST, "NonUniqueException 발생!"),
+    WRONG_DIRECTORY_TYPE(HttpStatus.BAD_REQUEST, "디렉토리 타입이 잘못되었습니다!"),
+    NOT_COMMENT_WRITER(HttpStatus.BAD_REQUEST, "댓글 작성자가 아닙니다!"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST"),
+
+    // 401 UNAUTHORIZED
+    ACCESS_REFUSED(HttpStatus.UNAUTHORIZED, "권한이 없습니다!"),
+    NOT_LOGGED_IN(HttpStatus.UNAUTHORIZED, "로그인 하지 않은 사용자입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED"),
+
+
+    // 404 NOT_FOUND
     NO_SUCH_DIRECTORY(HttpStatus.NOT_FOUND, "존재하지 않는 디렉토리 혹은 파일입니다! 확인 후 다시 시도해주세요."),
     NO_SUCH_ELEMENT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 자료입니다!"),
     NO_SUCH_WORKSPACE(HttpStatus.NOT_FOUND, "없는 작품입니다!"),
@@ -21,12 +31,8 @@ public enum ErrorCode {
     NO_SUCH_COMMENT_UUID(HttpStatus.NOT_FOUND, "존재하지 않는 코멘트 UUID입니다!"),
     NO_SUCH_COMMNET_INFO(HttpStatus.NOT_FOUND, "해당 댓글정보가 없습니다!"),
 
-    NOT_LOGGED_IN(HttpStatus.UNAUTHORIZED, "로그인 하지 않은 사용자입니다."),
-    WRONG_DIRECTORY_TYPE(HttpStatus.BAD_REQUEST, "디렉토리 타입이 잘못되었습니다!"),
-    NOT_COMMENT_WRITER(HttpStatus.BAD_REQUEST, "댓글 작성자가 아닙니다!"),
-
-    NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정보를 찾을수없습니다!");
-
+    DELETED_ELEMENT(HttpStatus.NOT_FOUND, "삭제된 자료입니다!"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND");
 
     private final HttpStatus status;
     private final String message;

--- a/server/src/test/java/com/galaxy/novelit/comment/service/CommentServiceTest.java
+++ b/server/src/test/java/com/galaxy/novelit/comment/service/CommentServiceTest.java
@@ -3,6 +3,7 @@ package com.galaxy.novelit.comment.service;
 import com.galaxy.novelit.comment.domain.CommentInfo;
 import com.galaxy.novelit.comment.entity.Comment;
 import com.galaxy.novelit.comment.repository.CommentRepository;
+import com.galaxy.novelit.comment.request.CommentDeleteRequest;
 import com.galaxy.novelit.comment.request.CommentUpdateRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,8 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class CommentServiceTest {
@@ -56,7 +59,7 @@ public class CommentServiceTest {
     }
 
     @Test
-    @DisplayName("댓글 수정 : MongoDB 영속성 테스트")
+    @DisplayName("댓글 수정하는 겸 MongoDB 영속성 테스트")
     void updateComment(){
         given(commentRepository.findCommentBySpaceUUID(any())).willReturn(Optional.ofNullable(comment));
 
@@ -69,5 +72,19 @@ public class CommentServiceTest {
         String expectedContent = "밥드세요우";
 
         Assertions.assertThat(expectedContent).isEqualTo(updateContent);
+    }
+
+    @Test
+    @DisplayName("댓글 삭제")
+    void deleteComment() throws Exception{
+        //given
+        given(commentRepository.findCommentBySpaceUUID(any())).willReturn(Optional.ofNullable(comment));
+
+        CommentDeleteRequest request = new CommentDeleteRequest(spaceUUID, commentUUID, "류현진");
+
+        commentService.deleteComment(request, userUUID);
+
+        Assertions.assertThat(commentRepository.findCommentBySpaceUUID(spaceUUID).get().getCommentInfoList().size())
+                .isEqualTo(0);
     }
 }


### PR DESCRIPTION
## Comment
### CommentService
- 댓글삭제 로직이 도메인쪽에 가까워서 옮김
- 조건들 validation 함수로 분리

## Exception
### ErrorCode
- Http 상태코드 별로 코드 분리
- 상태코드 별 범용적인 상태코드 추가

## Test
### CommentService
- 댓글 삭제 테스트
  - commentRepository를 건드는게 아니라 도메인을 업데이트 하기때문에 commentinfo 갯수가 0인지만 확인한다.